### PR TITLE
fix: add a dash to the default `failure_permitted` pattern

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -30,7 +30,7 @@ supported_oses:
 failure_permitted_pattern:
   type: str
   help: Enter a pattern (regex) for those test instances that should allow failure
-  default: master
+  default: -master
 renovate_presets:
   type: json
   help: Enter a list of Renovate presets you would like your configuration to extend from


### PR DESCRIPTION
Closes #43
